### PR TITLE
Adds middleware that adds charset to responses

### DIFF
--- a/src/ring/middleware/default_charset.clj
+++ b/src/ring/middleware/default_charset.clj
@@ -1,0 +1,31 @@
+(ns ring.middleware.default-charset
+  "Middleware for automatically adding a charset to the content-type header in
+  response maps."
+  (:require [ring.util.response :as response]))
+
+(defn- text-based-content-type? [content-type]
+  (or (re-find #"text/" content-type)
+      (re-find #"application/(xml|json)" content-type)))
+
+(defn- contains-charset? [content-type]
+  (re-find #";\s*charset=[^;]*" content-type))
+
+(defn- add-charset [resp charset]
+  (if-let [content-type (response/get-header resp "Content-Type")]
+    (if (and (text-based-content-type? content-type)
+             (not (contains-charset? content-type)))
+      (response/charset resp charset)
+      resp)
+    resp))
+
+(defn wrap-default-charset
+  "Middleware that adds a charset to the content-type header of the response if
+  one was not set by the handler. Adds the specified charset or defaults to
+  utf-8 if no charset is specified."
+  {:arglists '([handler] [handler charset])}
+  ([handler]
+   (wrap-default-charset handler "utf-8"))
+  ([handler charset]
+   (fn [req]
+     (if-let [resp (handler req)]
+       (add-charset resp charset)))))

--- a/test/ring/middleware/default_charset_test.clj
+++ b/test/ring/middleware/default_charset_test.clj
@@ -1,0 +1,55 @@
+(ns ring.middleware.default-charset-test
+  (:use clojure.test
+        ring.middleware.default-charset
+        [ring.mock.request :only [request]]
+        [ring.util.response :only [charset content-type]]))
+
+(deftest test-wrap-charset
+  (testing "no charset specified"
+    (testing "no content-type header present"
+      (let [handler (wrap-default-charset (constantly {}))
+            resp    (handler request)]
+        (is (= resp {}))))
+
+    (testing "content-type header without charset present"
+      (let [handler (wrap-default-charset
+                      (constantly (content-type {} "text/html")))
+            resp    (handler request)]
+        (is (= (:headers resp)
+               {"Content-Type" "text/html; charset=utf-8"}))))
+
+    (testing "content-type header with charset present"
+      (let [handler (wrap-default-charset
+                      (constantly (-> {} (content-type "text/html") (charset "utf-16"))))
+            resp    (handler request)]
+        (is (= (:headers resp)
+               {"Content-Type" "text/html; charset=utf-16"})))))
+
+  (testing "charset specified"
+    (testing "no content-type header present"
+      (let [handler (wrap-default-charset (constantly {}) "utf-16")
+            resp    (handler request)]
+        (is (= resp {}))))
+
+    (testing "content-type header without charset present"
+      (let [handler (wrap-default-charset
+                      (constantly (content-type {} "text/html"))
+                      "utf-16")
+            resp    (handler request)]
+        (is (= (:headers resp)
+               {"Content-Type" "text/html; charset=utf-16"}))))
+
+    (testing "content-type header with charset present"
+      (let [handler (wrap-default-charset
+                      (constantly (-> {} (content-type "text/html") (charset "utf-8")))
+                      "utf-16")
+            resp    (handler request)]
+        (is (= (:headers resp)
+               {"Content-Type" "text/html; charset=utf-8"})))))
+
+  (testing "non-text-based content-type"
+    (let [handler (wrap-default-charset
+                    (constantly (content-type {} "application/gzip")))
+          resp    (handler request)]
+      (is (= (:headers resp)
+             {"Content-Type" "application/gzip"})))))


### PR DESCRIPTION
Adds the specified charset or "utf-8" to response maps with a content-type
header that specifies a text-based media-type, but no charset.

As first suggested in https://github.com/ring-clojure/ring-defaults/issues/13. 