### PR TITLE
Add absolute redirect support for resource creation

### DIFF
--- a/src/ring/middleware/absolute_redirects.clj
+++ b/src/ring/middleware/absolute_redirects.clj
@@ -6,7 +6,7 @@
   (:import  [java.net URL MalformedURLException]))
 
 (defn- redirect? [response]
-  (#{301 302 303 307} (:status response)))
+  (#{201 301 302 303 307} (:status response)))
 
 (defn- get-header-key [response ^String header-name]
   (->> response :headers keys

--- a/test/ring/middleware/absolute_redirects_test.clj
+++ b/test/ring/middleware/absolute_redirects_test.clj
@@ -2,7 +2,7 @@
   (:use clojure.test
         ring.middleware.absolute-redirects
         [ring.mock.request :only [request]]
-        [ring.util.response :only [redirect response content-type]]))
+        [ring.util.response :only [redirect response content-type created]]))
 
 (deftest test-wrap-absolute-redirects
   (testing "relative redirects"
@@ -37,4 +37,9 @@
           resp    (handler (request :get "/"))]
       (is (= (:status resp) 302))
       (is (= (:headers resp) {"Location" "http://localhost/foo"
-                              "Content-Type" "text/plain"})))))
+                              "Content-Type" "text/plain"}))))
+  (testing "resource creation"
+    (let [handler (wrap-absolute-redirects (constantly (created "/bar/1")))
+          resp    (handler (request :post "/bar"))]
+      (is (= (:status resp) 201))
+      (is (= (:headers resp) {"Location" "http://localhost/bar/1"})))))


### PR DESCRIPTION
When creating a new resource, it's common to return a Location header with an HTTP status code 201. The following pull-request adds support to turn relative URLs returned from the `created` response to absolute ones.