### PR TITLE
Fix comment referencing obsolete RFC 2616

### DIFF
--- a/src/ring/middleware/absolute_redirects.clj
+++ b/src/ring/middleware/absolute_redirects.clj
@@ -38,9 +38,9 @@
 
 (defn wrap-absolute-redirects
   "Middleware that converts redirects to relative URLs into redirects to
-  absolute URLs. While many browsers can handle relative URLs in the Location
-  header, RFC 2616 states that the Location header must contain an absolute
-  URL."
+  absolute URLs. This was originally mandated by RFC 2616, but RFC 7231 and
+  RFC 9110, which since obsoleted it, explicitly describe the semantics for
+  relative URIs."
   [handler]
   (fn
     ([request]


### PR DESCRIPTION
ring/ring-defaults 0.3.4 changed the default value for absolute URIs in `Location` headers in https://github.com/ring-clojure/ring-defaults/commit/5daefefd76d2655a474253d3b0cd853e136c3711.
This PR changes the comment on the actual middleware that still described absolute URIs as mandatory.