### PR TITLE
Add support for Authorization request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://travis-ci.org/ring-clojure/ring-headers.svg?branch=master)](https://travis-ci.org/ring-clojure/ring-headers)
 
-Ring middleware for adding and manipulating common response headers.
+Ring middleware for parsing common request headers, and for adding and
+manipulating common response headers.
 
 ## Installation
 

--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,14 @@
   :url "https://github.com/ring-clojure/ring-headers"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [ring/ring-core "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [ring/ring-core "1.8.1"]]
   :plugins [[lein-codox "0.10.3"]]
   :codox {:project {:name "Ring-Headers"}
           :output-path "codox"}
-  :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8:+1.9" "test"]}
+  :aliases {"test-all" ["with-profile" "default:+1.7:+1.8:+1.9" "test"]}
   :profiles
   {:dev {:dependencies [[ring/ring-mock "0.3.0"]]}
-   :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha10"]]}})

--- a/src/ring/middleware/authorization.clj
+++ b/src/ring/middleware/authorization.clj
@@ -1,0 +1,56 @@
+(ns ring.middleware.authorization
+  (:require [clojure.string :as str]
+            [ring.util.parsing :as parsing]))
+
+(def ^:private re-token68
+  (re-pattern "[A-Za-z0-9._~+/-]+=*"))
+
+(def ^:private re-auth-param
+  (re-pattern (str "(" parsing/re-token ")\\s*=\\s*(?:" parsing/re-value ")")))
+
+(defn- parse-auth-params [auth-params]
+  (reduce (fn [m kv]
+            (if-let [[_ k v1 v2] (re-matches re-auth-param kv)]
+              (assoc m (str/lower-case k) (or v1 v2))
+              m))
+          {}
+          (str/split auth-params #"\s*,\s*")))
+
+(defn- parse-authorization [request]
+  (when-let [[auth-scheme token-or-params]
+             (some-> (get-in request [:headers "authorization"])
+                     (str/split #"\s" 2))]
+    (cond
+      (empty? token-or-params)
+      {:scheme (str/lower-case auth-scheme)}
+
+      (re-matches re-token68 token-or-params)
+      {:scheme (str/lower-case auth-scheme)
+       :token token-or-params}
+
+      :else
+      {:scheme (str/lower-case auth-scheme)
+       :params (parse-auth-params token-or-params)})))
+
+(defn authorization-request
+  "Parses Authorization header in the request map. See: wrap-authorization."
+  [request]
+  (if (:authorization request)
+    request
+    (assoc request :authorization (parse-authorization request))))
+
+(defn wrap-authorization
+  "Parses the Authorization header in the request map, then assocs the result
+  to the :authorization key on the request.
+
+  See RFC 7235 Section 2 and RFC 9110 Section 11:
+  * https://datatracker.ietf.org/doc/html/rfc7235#section-2
+  * https://datatracker.ietf.org/doc/html/rfc9110#section-11"
+  [handler]
+  (fn
+    ([request]
+     (handler (authorization-request request)))
+    ([request respond raise]
+     (handler (authorization-request request)
+              respond
+              raise))))

--- a/test/ring/middleware/authorization_test.clj
+++ b/test/ring/middleware/authorization_test.clj
@@ -1,0 +1,90 @@
+(ns ring.middleware.authorization-test
+  (:require [clojure.test :refer :all]
+            [ring.middleware.authorization :refer :all]))
+
+(deftest test-authorization-request
+  (testing "pre-existing authorization"
+    (is (= "TEST"
+           (-> {:headers       {"authorization" "Basic"}
+                :authorization "TEST"}
+               authorization-request
+               :authorization))))
+  (testing "no authorization"
+    (is (nil? (-> {:headers {}}
+                authorization-request
+                :authorization))))
+  (testing "scheme without token"
+    (is (= {:scheme "basic"}
+           (-> {:headers {"authorization" "Basic"}}
+               authorization-request
+               :authorization))))
+  (testing "scheme with zero-length token"
+    (is (= {:scheme "basic"}
+           (-> {:headers {"authorization" "Basic "}}
+               authorization-request
+               :authorization))))
+  (testing "token68"
+    (is (= {:scheme "basic"
+            :token "dGVzdA=="}
+           (-> {:headers {"authorization" "Basic dGVzdA=="}}
+               authorization-request
+               :authorization))))
+  (testing "auth-params, some malformed"
+    (is (= {:scheme "digest"
+            :params {"a"    "B"
+                     "c"    "d"
+                     "eeee" "dGVzdA=="
+                     "k"    "1"}}
+           (-> {:headers {"authorization" "Digest A=B, c=\"d\",
+     eeee=\"dGVzdA==\", fparam=dGVzdA==, g, \"h\"=i, =j, = ,, , k=1"}}
+               authorization-request
+               :authorization)))))
+
+(deftest test-wrap-authorization-none
+  (let [handler   (wrap-authorization (fn [req respond _] (respond req)))
+        request   {:headers {}}
+        response  (promise)
+        exception (promise)]
+    (handler request response exception)
+    (is (nil? (:authorization @response)))
+    (is (not (realized? exception)))))
+
+(deftest test-wrap-authorization-scheme-only
+  (let [handler   (wrap-authorization (fn [req respond _] (respond req)))
+        request   {:headers {"authorization" "Basic"}}
+        response  (promise)
+        exception (promise)]
+    (handler request response exception)
+    (is (= {:scheme  "basic"}
+           (:authorization @response)))
+    (is (not (realized? exception)))))
+
+(deftest test-wrap-authorization-token68
+  (let [handler   (wrap-authorization (fn [req respond _] (respond req)))
+        request   {:headers {"authorization" "Basic dGVzdA=="}}
+        response  (promise)
+        exception (promise)]
+    (handler request response exception)
+    (is (= {:scheme  "basic"
+            :token "dGVzdA=="}
+           (:authorization @response)))
+    (is (not (realized? exception)))))
+
+(deftest test-wrap-authorization-auth-params
+  (let [handler   (wrap-authorization (fn [req respond _] (respond req)))
+        request   {:headers {"authorization" "Digest A=\"B\""}}
+        response  (promise)
+        exception (promise)]
+    (handler request response exception)
+    (is (= {:params {"a" "B"}
+            :scheme "digest"}
+           (:authorization @response)))
+    (is (not (realized? exception)))))
+
+(deftest test-wrap-authorization-synchronous
+  (let [request (atom nil)
+        handler (wrap-authorization (fn [req] (reset! request req)))]
+    (handler {:headers {"authorization" "Basic A=\"B\""}})
+    (is (= {:params {"a" "B"}
+            :scheme "basic"}
+           (:authorization @request)))))


### PR DESCRIPTION
No complete authentication scheme, but the "Access Authentication Framework"
defined by RFC 7235, providing the building blocks to implement auth schemes.

* https://datatracker.ietf.org/doc/html/rfc7235
* https://datatracker.ietf.org/doc/html/rfc9110#section-11

Raises dependency on ring-core to 1.8.1.  `ring.util.parsing/re-value` was
added in 1.3, but until 1.8.1 it did not capture the content of quoted values
without the quotes. This drops support for Clojure 1.5 and 1.6, since 1.8.1
requires Clojure 1.7.