### PR TITLE
Update Clojure to 1.9.0 (addresses CVE-2017-20189)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring-headers"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring/ring-core "1.6.0"]]
   :plugins [[lein-codox "0.10.3"]]
   :codox {:project {:name "Ring-Headers"}


### PR DESCRIPTION
[CVE-2017-20189](https://nvd.nist.gov/vuln/detail/CVE-2017-20189) is a critical security vulnerability affecting versions of Clojure prior to `1.9.0`.

Can we bump this project's dependency to `1.9.0` and cut a new release?