### PR TITLE
Make r.m.authorization/parse-authorization public

### DIFF
--- a/src/ring/middleware/authorization.clj
+++ b/src/ring/middleware/authorization.clj
@@ -16,10 +16,16 @@
           {}
           (str/split auth-params #"\s*,\s*")))
 
-(defn- parse-authorization [request]
+(defn parse-credentials
+  "Parse credentials as used in the Authorization header of an HTTP
+  request.
+
+  Note: The WWW-Authenticate header of an HTTP response contains a
+  comma-separated list of challenges, which each happen to have the same
+  structure as the single credentials in the Authorization header."
+  [credentials]
   (when-let [[auth-scheme token-or-params]
-             (some-> (get-in request [:headers "authorization"])
-                     (str/split #"\s" 2))]
+             (some-> credentials (str/split #"\s" 2))]
     (cond
       (empty? token-or-params)
       {:scheme (str/lower-case auth-scheme)}
@@ -37,7 +43,7 @@
   [request]
   (if (:authorization request)
     request
-    (assoc request :authorization (parse-authorization request))))
+    (assoc request :authorization (parse-credentials (get-in request [:headers "authorization"])))))
 
 (defn wrap-authorization
   "Parses the Authorization header in the request map, then assocs the result

--- a/test/ring/middleware/authorization_test.clj
+++ b/test/ring/middleware/authorization_test.clj
@@ -2,6 +2,29 @@
   (:require [clojure.test :refer :all]
             [ring.middleware.authorization :refer :all]))
 
+(deftest test-parse-authorization
+  (testing "no authorization"
+    (is (nil? (parse-credentials nil))))
+  (testing "scheme without token"
+    (is (= {:scheme "basic"}
+           (parse-credentials "Basic"))))
+  (testing "scheme with zero-length token"
+    (is (= {:scheme "basic"}
+           (parse-credentials "Basic "))))
+  (testing "token68"
+    (is (= {:scheme "basic"
+            :token "dGVzdA=="}
+           (parse-credentials "Basic dGVzdA=="))))
+  (testing "auth-params, some malformed"
+    (is (= {:scheme "digest"
+            :params {"a"    "B"
+                     "c"    "d"
+                     "eeee" "dGVzdA=="
+                     "k"    "1"
+                     "l"    "234"}}
+           (parse-credentials "Digest A=B, c=\"d\",
+     eeee=\"dGVzdA==\", fparam=dGVzdA==, g, \"h\"=i, =j, = ,, , k=1, l = \"234\"")))))
+
 (deftest test-authorization-request
   (testing "pre-existing authorization"
     (is (= "TEST"
@@ -11,34 +34,12 @@
                :authorization))))
   (testing "no authorization"
     (is (nil? (-> {:headers {}}
-                authorization-request
-                :authorization))))
-  (testing "scheme without token"
-    (is (= {:scheme "basic"}
-           (-> {:headers {"authorization" "Basic"}}
-               authorization-request
-               :authorization))))
-  (testing "scheme with zero-length token"
-    (is (= {:scheme "basic"}
-           (-> {:headers {"authorization" "Basic "}}
-               authorization-request
-               :authorization))))
-  (testing "token68"
-    (is (= {:scheme "basic"
-            :token "dGVzdA=="}
-           (-> {:headers {"authorization" "Basic dGVzdA=="}}
-               authorization-request
-               :authorization))))
-  (testing "auth-params, some malformed"
-    (is (= {:scheme "digest"
-            :params {"a"    "B"
-                     "c"    "d"
-                     "eeee" "dGVzdA=="
-                     "k"    "1"}}
-           (-> {:headers {"authorization" "Digest A=B, c=\"d\",
-     eeee=\"dGVzdA==\", fparam=dGVzdA==, g, \"h\"=i, =j, = ,, , k=1"}}
-               authorization-request
-               :authorization)))))
+                  authorization-request
+                  :authorization))))
+  (testing "with authorization"
+    (is (some? (-> {:headers {"authorization" "Basic"}}
+                   authorization-request
+                   :authorization)))))
 
 (deftest test-wrap-authorization-none
   (let [handler   (wrap-authorization (fn [req respond _] (respond req)))


### PR DESCRIPTION
Make the existing `ring.middleware.authorization/parse-authorization`
function public and make it take the `Authorization` header value as
input.

According to RFC 7235 Section 2 and RFC 9110 Section 11, the value
`credentials` of the `Authorization` HTTP request header has the same
structure as each of the comma-separated `challenge`s of the
`WWW-Authenticate` HTTP response header, which allows to reuse this
function also for parsing responses:
  * https://datatracker.ietf.org/doc/html/rfc7235#section-2
  * https://datatracker.ietf.org/doc/html/rfc9110#section-11